### PR TITLE
Bump nokogiri to 1.6.0 & json 1.8.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
 gem "rspec", "~> 2.13.0"
-gem "nokogiri", "~> 1.5.9"
-gem "json", "~> 1.7.7"
+gem "nokogiri", "~> 1.6.0"
+gem "json", "~> 1.8.0"
 gem "fuubar"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,8 +6,10 @@ GEM
       rspec (~> 2.0)
       rspec-instafail (~> 0.2.0)
       ruby-progressbar (~> 1.0.0)
-    json (1.7.7)
-    nokogiri (1.5.9)
+    json (1.8.0)
+    mini_portile (0.5.0)
+    nokogiri (1.6.0)
+      mini_portile (~> 0.5.0)
     rspec (2.13.0)
       rspec-core (~> 2.13.0)
       rspec-expectations (~> 2.13.0)
@@ -24,6 +26,6 @@ PLATFORMS
 
 DEPENDENCIES
   fuubar
-  json (~> 1.7.7)
-  nokogiri (~> 1.5.9)
+  json (~> 1.8.0)
+  nokogiri (~> 1.6.0)
   rspec (~> 2.13.0)

--- a/bing_translator.gemspec
+++ b/bing_translator.gemspec
@@ -1,13 +1,13 @@
 Gem::Specification.new do |s|
   s.name        = 'bing_translator'
-  s.version     = '3.2.0'
-  s.date        = '2013-04-29'
+  s.version     = '3.2.1'
+  s.date        = '2013-06-20'
   s.homepage    = 'https://www.github.com/CodeBlock/bing_translator-gem'
   s.summary     = "Translate using the Bing HTTP API"
   s.description = "Translate strings using the Bing HTTP API. Requires that you have a Client ID and Secret. See README.md for information."
   s.authors     = ["Ricky Elrod"]
   s.email       = 'ricky@elrod.me'
   s.files       = ["lib/bing_translator.rb"]
-  s.add_dependency "nokogiri", "~> 1.5.9"
-  s.add_dependency "json", "~> 1.7.7"
+  s.add_dependency "nokogiri", "~> 1.6.0"
+  s.add_dependency "json", "~> 1.8.0"
 end


### PR DESCRIPTION
Needed to bump these to retain compatibility with other gems. Specs pass and all seems well.
