### PR TITLE
Add the ability to specify the content type

### DIFF
--- a/lib/bing_translator.rb
+++ b/lib/bing_translator.rb
@@ -40,10 +40,10 @@ class BingTranslator
 
     from = CGI.escape params[:from].to_s
     params = {
-      'to' => CGI.escape(params[:to].to_s),
-      'text' => CGI.escape(text.to_s),
-      'category' => 'general',
-      'contentType' => 'text/plain'
+      'to'          => CGI.escape(params[:to].to_s),
+      'text'        => CGI.escape(text.to_s),
+      'category'    => 'general',
+      'contentType' => params[:content_type] || 'text/plain'
     }
     params[:from] = from unless from.empty?
     result = result @translate_uri, params


### PR DESCRIPTION
The API also [supports](http://msdn.microsoft.com/en-us/library/ff512406.aspx) HTML as a content type which could be useful.

It's kind of hard to test but the change is quite basic.
