### PR TITLE
update version number in readme exmaple to latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ To use this rubygem:
 
 With bundler:
 
-    gem "bing_translator", "~> 4.0.0"
+    gem "bing_translator", "~> 4.3.0"
 
 Information
 ===========


### PR DESCRIPTION
The older version number in the readme bundler example threw me off (same issue as #16). Updated it to the current version.
