### PR TITLE
Rails 2.1.3 fix

### DIFF
--- a/bing_translator.gemspec
+++ b/bing_translator.gemspec
@@ -11,5 +11,5 @@ Gem::Specification.new do |s|
   s.licenses    = ["MIT"]
   s.add_dependency "nokogiri", "~> 1.6.0"
   s.add_dependency "json", "~> 1.8.0"
-  s.add_dependency "savon", "~> 2.0"
+  s.add_dependency "savon", "~> 2.10.0"
 end


### PR DESCRIPTION
Issue resolved: Invalid version of rubyntlm. Please use v0.3.2+

Description: Rails projects fail to work with savon 2.0.0. The problem gets solved, once savon 2.10.0 is used.