### PR TITLE
Translator object to recover from failed authentication attempts

### DIFF
--- a/lib/bing_translator.rb
+++ b/lib/bing_translator.rb
@@ -202,7 +202,7 @@ private
   # Return stored client while access token is fresh.
   # Construct and store new client when token have been expired.
   def soap_client
-    return @client if @client and @access_token and
+    return @client if @client and @access_token and @access_token['expires_at'] and
       Time.now < @access_token['expires_at']
 
     @client = Savon.client(

--- a/lib/bing_translator.rb
+++ b/lib/bing_translator.rb
@@ -143,7 +143,7 @@ class BingTranslator
   # Returns existing @access_token if we don't need a new token yet,
   # or returns the one just obtained.
   def get_access_token
-    return @access_token if @access_token and
+    return @access_token if @access_token and @access_token['expires_at'] and
       Time.now < @access_token['expires_at']
 
     params = {

--- a/spec/bing_translator_spec.rb
+++ b/spec/bing_translator_spec.rb
@@ -125,9 +125,20 @@ describe BingTranslator do
     translator.language_names(['en', 'es', 'de'], 'de').should == ['Englisch', 'Spanisch', 'Deutsch']
   end
 
-  it "throws a BingTranslatorAuthenticationException exception on invalid credentials" do
-    translator = BingTranslator.new("", "")
-    expect { translator.translate 'hola', :from => :es, :to => :en }.to raise_error(BingTranslator::AuthenticationException)
+  context 'when credentials are invalid' do
+    let(:translator) { BingTranslator.new("", "") }
+
+    subject { translator.translate 'hola', :from => :es, :to => :en }
+
+    it "throws a BingTranslator::AuthenticationException exception" do
+      expect { subject }.to raise_error(BingTranslator::AuthenticationException)
+    end
+
+    context "trying to translate something twice" do
+      it "throws the BingTranslator::AuthenticationException exception every time" do
+        2.times { expect { subject }.to raise_error(BingTranslator::AuthenticationException) }
+      end
+    end
   end
 
   describe "#balance" do


### PR DESCRIPTION
Howdy!

I keep a BingTranslator instance as a class variable and it looks like such an instance may get broken when something unexpected happens on the Bing side and make their API responding with server errors and not allowing to sign in (it's not a theoretical case, something like that happened yesterday - we've got 'server busy' error message).

Generally, after unsuccessful attempt of obtaining a token (`BingTranslator::AuthenticationException`), all the subsequent calls to the API will fail with error message`BingTranslator::Exception: comparison of Time with nil failed`. I think a translator object should be able to recover from that and try to login again in subsequent calls.

I created a very simple patch for it, should not affect core functionality.

Best,
Kamil