### PR TITLE
Add support for Azure Cognitive Services Auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,7 @@ Bing Translator
 
 [![Gem](https://img.shields.io/gem/v/bing_translator.svg)](https://rubygems.org/gems/bing_translator/) [![Build Status](https://travis-ci.org/relrod/bing_translator-gem.svg?branch=master)](https://travis-ci.org/relrod/bing_translator-gem)
 
-This gem wraps the Microsoft Bing SOAP Translate API.
-I am in no way affiliated with Microsoft or Bing.
-Use this gem at your own risk.
-
-Released under MIT.
-Tested against MRI 2.1.0, 2.0.0 and 1.9.3, and jruby (1.9 mode).
+This gem wraps the Microsoft Cognitive Services Translator API.
 
 Installation
 ============
@@ -19,38 +14,27 @@ To use this rubygem:
 
 With bundler:
 
-    gem "bing_translator", "~> 4.5.0"
+    gem "bing_translator", "~> 4.7.0"
 
 Information
 ===========
 
-Version 2.0.0+ of bing\_translator uses the new OAuth-based Bing
-authentication.
-
-Documentation on the Microsoft Translator API is [here](http://msdn.microsoft.com/en-us/library/ff512419.aspx)
+Documentation on the Microsoft Translator API is [here](https://www.microsoft.com/cognitive-services/en-us/translator-api)
 
 bing\_translator is also smart about requesting the token, and handles this
 behind the scenes. It will only request a token if it knows the old one
 expired (X seconds from when we requested the last token, where X is given
-to us when we make the request. As of this writing, X is consistently 10
+to us when we make the request. As of this writing, X is consistently 8
 minutes).
 
-Getting a Client ID and Secret
+Getting a free Azure account  
 ==============================
 
-To sign up for the free tier (as of this writing), do the following:
+To be able to use the API freely, do the following:
 
-1. Go [here](http://go.microsoft.com/?linkid=9782667)
-2. Sign in with valid MSN credentials.
-3. On the right side, click 'SIGN UP', under the $0.00 option.
-4. Read and accept the terms and conditions and click the big 'SIGN UP'
-   button.
-5. [Create a new application](https://datamarket.azure.com/developer/applications).
-   Fill in a unique client ID, give it a valid name, give it a valid redirect
-   URI (not actually used by the Bing Translator API, so it can be anything)
-   and hit 'CREATE'.
-6. Click on the name of your application to see the info again. You'll need
-   the 'Client ID' and 'Client secret' fields.
+1. Go [here](https://azure.microsoft.com/en-us/free/)
+2. Sign in with valid Live credentials.
+3. Add the resource 'Cognitive Services APIs'
 
 Usage
 =====
@@ -59,16 +43,22 @@ Usage
 require 'rubygems'
 require 'bing_translator'
 
-# Specify all arguments
-translator = BingTranslator.new('YOUR_CLIENT_ID', 'YOUR_CLIENT_SECRET', false, 'AZURE_ACCOUNT_KEY')
+translator = BingTranslator.new('COGNITIVE_SUBSCRIPTION_KEY')
 
-# Or... Specify only required arguments
-translator = BingTranslator.new('YOUR_CLIENT_ID', 'YOUR_CLIENT_SECRET')
+# Translation
 
 spanish = translator.translate('Hello. This will be translated!', :from => 'en', :to => 'es')
-
-# without :from for auto language detection
 spanish = translator.translate('Hello. This will be translated!', :to => 'es')
+
+# Translation of multiple strings
+
+result = translator.translate_array(['Hello. This will be translated!', 'This will be translated too!'], :from => :en, :to => :fr)
+
+# Translation of multiple strings, with word alignment information
+
+result = translator.translate_array(['Hello. This will be translated!', 'This will be translated too!'], :from => :en, :to => :fr)
+
+# Language Detection
 
 locale = translator.detect('Hello. This will be translated!') # => :en
 
@@ -76,24 +66,5 @@ locale = translator.detect('Hello. This will be translated!') # => :en
 # It does not translate the text. Format can be 'audio/mp3' or 'audio/wav'
 
 audio = translator.speak('Hello. This will be spoken!', :language => :en, :format => 'audio/mp3', :options => 'MaxQuality')
-open('file.mp3', 'wb') { |f| f.write audio }
-
-# Account balance
-translator.balance # => 20000
-
-# get_access_token example
-# Useful, e.g., for using bing_translator in a web application frontend
-def get_access_token
-  begin
-    translator = BingTranslator.new('YOUR_CLIENT_ID', 'YOUR_CLIENT_SECRET', false, 'AZURE_ACCOUNT_KEY')
-    token = translator.get_access_token
-    token[:status] = 'success'
-  rescue Exception => exception
-    YourApp.error_logger.error("Bing Translator: \"#{exception.message}\"")
-    token = { :status => exception.message }
-  end
-
-  token
-end
-
+File.write('file.mp3', audio, mode: 'wb')
 ```

--- a/bing_translator.gemspec
+++ b/bing_translator.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name        = 'bing_translator'
-  s.version     = '4.6.0'
-  s.date        = '2016-04-22'
+  s.version     = '4.7.0'
+  s.date        = '2017-02-24'
   s.homepage    = 'https://www.github.com/relrod/bing_translator-gem'
   s.summary     = "Translate using the Bing HTTP API"
   s.description = "Translate strings using the Bing HTTP API. Requires that you have a Client ID and Secret. See README.md for information."

--- a/bing_translator.gemspec
+++ b/bing_translator.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name        = 'bing_translator'
-  s.version     = '4.7.0'
-  s.date        = '2017-02-24'
+  s.version     = '5.0.0'
+  s.date        = '2017-03-01'
   s.homepage    = 'https://www.github.com/relrod/bing_translator-gem'
   s.summary     = "Translate using the Bing HTTP API"
   s.description = "Translate strings using the Bing HTTP API. Requires that you have a Client ID and Secret. See README.md for information."

--- a/lib/bing_translator.rb
+++ b/lib/bing_translator.rb
@@ -14,23 +14,13 @@ require 'savon'
 class BingTranslator
   WSDL_URI = 'http://api.microsofttranslator.com/V2/soap.svc?wsdl'
   NAMESPACE_URI = 'http://api.microsofttranslator.com/V2'
-  ACCESS_TOKEN_URI = 'https://datamarket.accesscontrol.windows.net/v2/OAuth2-13'
-  DATASETS_URI = "https://api.datamarket.azure.com/Services/My/Datasets?$format=json"
-  COGNITIVE_ACCESS_TOKEN_URI = 'https://api.cognitive.microsoft.com/sts/v1.0/issueToken'
+  COGNITIVE_ACCESS_TOKEN_URI = URI.parse('https://api.cognitive.microsoft.com/sts/v1.0/issueToken').freeze
 
   class Exception < StandardError; end
-  class AuthenticationException < StandardError; end
 
-  def initialize(client_id: nil, client_secret: nil, skip_ssl_verify: false, account_key: nil, subscription_key: nil)
-    @client_id = client_id
-    @client_secret = client_secret
-    @skip_ssl_verify = skip_ssl_verify
-    @account_key = account_key
+  def initialize(subscription_key, options = {})
+    @skip_ssl_verify = options.fetch(:skip_ssl_verify, false)
     @subscription_key = subscription_key
-
-    @access_token_uri = URI.parse(ACCESS_TOKEN_URI)
-    @datasets_uri = URI.parse(DATASETS_URI)
-    @cognitive_token_uri = URI.parse(COGNITIVE_ACCESS_TOKEN_URI)
   end
 
   def translate(text, params = {})
@@ -77,7 +67,6 @@ class BingTranslator
 
     array_wrap(result(:translate_array2, params)[:translate_array2_response]).map{|r| [r[:translated_text], r[:alignment]]}
   end
-
 
   def detect(text)
     params = {
@@ -130,41 +119,23 @@ class BingTranslator
     response[:string]
   end
 
-  def balance
-    datasets["d"]["results"].each do |result|
-      return result["ResourceBalance"] if result["ProviderName"] == "Microsoft Translator"
-    end
-  end
+  private
 
   # Get a new access token and set it internally as @access_token
-  #
-  # Microsoft changed up how you get access to the Translate API.
-  # This gets a new token if it's required. We call this internally
-  # before any request we make to the Translate API.
   #
   # @return {hash}
   # Returns existing @access_token if we don't need a new token yet,
   # or returns the one just obtained.
   def get_access_token
-    if @subscription_key
-      get_cognitive_access_token
-    else
-      get_datamarket_access_token
-    end
-  end
-
-private
-
-  def get_cognitive_access_token
     headers = {
       'Ocp-Apim-Subscription-Key' => @subscription_key
     }
 
-    http = Net::HTTP.new(@cognitive_token_uri.host, @cognitive_token_uri.port)
+    http = Net::HTTP.new(COGNITIVE_ACCESS_TOKEN_URI.host, COGNITIVE_ACCESS_TOKEN_URI.port)
     http.use_ssl = true
     http.verify_mode = OpenSSL::SSL::VERIFY_NONE if @skip_ssl_verify
 
-    response = http.post(@cognitive_token_uri.path, "", headers)
+    response = http.post(COGNITIVE_ACCESS_TOKEN_URI.path, "", headers)
 
     @access_token = {
       'access_token' => response.body,
@@ -172,57 +143,18 @@ private
     }
   end
 
-  def get_datamarket_access_token
-    return @access_token if @access_token and @access_token['expires_at'] and
-      Time.now < @access_token['expires_at']
-
-    params = {
-      'client_id' => CGI.escape(@client_id),
-      'client_secret' => CGI.escape(@client_secret),
-      'scope' => CGI.escape('http://api.microsofttranslator.com'),
-      'grant_type' => 'client_credentials'
-    }
-
-    http = Net::HTTP.new(@access_token_uri.host, @access_token_uri.port)
-    http.use_ssl = true
-    http.verify_mode = OpenSSL::SSL::VERIFY_NONE if @skip_ssl_verify
-
-    response = http.post(@access_token_uri.path, prepare_param_string(params))
-    @access_token = JSON.parse(response.body)
-    raise AuthenticationException, @access_token['error'] if @access_token["error"]
-    @access_token['expires_at'] = Time.now + @access_token['expires_in'].to_i
-    @access_token
+  # Performs actual request to Bing Translator SOAP API
+  def result(action, params = {}, &block)    
+    soap_client.call(action, message: build_soap_message(params), &block).body[:"#{action}_response"][:"#{action}_result"]
+  rescue Savon::SOAPFault => e
+    raise Exception, e.message
   end
 
-  def datasets
-    raise AuthenticationException, "Must provide account key" if @account_key.nil?
-
-    http = Net::HTTP.new(@datasets_uri.host, @datasets_uri.port)
-    http.use_ssl = true
-    http.verify_mode = OpenSSL::SSL::VERIFY_NONE
-    request = Net::HTTP::Get.new(@datasets_uri.request_uri)
-    request.basic_auth("", @account_key)
-    response = http.request(request)
-
-    JSON.parse response.body
-  end
-
-  def prepare_param_string(params)
-    params.map { |key, value| "#{key}=#{value}" }.join '&'
-  end
-
-  # Public: performs actual request to Bing Translator SOAP API
-  def result(action, params = {}, &block)
-    # Specify SOAP namespace in tag names (see https://github.com/savonrb/savon/issues/340 )
-    params = Hash[params.map{|k,v| ["v2:#{k}", v]}]
-    begin
-      soap_client.call(action, message: params, &block).body[:"#{action}_response"][:"#{action}_result"]
-    rescue AuthenticationException
-      raise
-    rescue StandardError => e
-      # Keep old behaviour: raise only internal Exception class
-      raise Exception, e.message
-    end
+  # Specify SOAP namespace in tag names (see https://github.com/savonrb/savon/issues/340 )
+  #
+  # @return [Hash]
+  def build_soap_message(params)    
+    Hash[params.map{|k,v| ["v2:#{k}", v]}]
   end
 
   # Private: Constructs SOAP client

--- a/lib/bing_translator.rb
+++ b/lib/bing_translator.rb
@@ -74,7 +74,9 @@ class BingTranslator
       'language' => '',
     }
 
-    result(:detect, params).to_sym
+    if lang = result(:detect, params)
+      lang.to_sym
+    end
   end
 
   # format:   'audio/wav' [default] or 'audio/mp3'

--- a/spec/bing_translator_spec.rb
+++ b/spec/bing_translator_spec.rb
@@ -11,11 +11,8 @@ describe BingTranslator do
   let(:long_unicode_text) { File.read(File.join(File.dirname(__FILE__), 'long_unicode_text.txt')) }
   let(:long_html_text) { File.read(File.join(File.dirname(__FILE__), 'long_text.html')) }
   let(:translator) {
-    BingTranslator.new(client_id: ENV['BING_TRANSLATOR_TEST_CLIENT_ID'],
-      client_secret: ENV['BING_TRANSLATOR_TEST_CLIENT_SECRET'],
-      skip_ssl_verify: false,
-      account_key: ENV['AZURE_TEST_ACCOUNT_KEY'],
-      subscription_key: ENV['COGNITIVE_SUBSCRIPTION_KEY'])
+    BingTranslator.new(ENV['COGNITIVE_SUBSCRIPTION_KEY'],
+      skip_ssl_verify: false)
   }
 
   it "translates text" do
@@ -111,35 +108,17 @@ describe BingTranslator do
   end
 
   context 'when credentials are invalid' do
-    let(:translator) { BingTranslator.new(client_id: "", client_secret: "") }
+    let(:translator) { BingTranslator.new("") }
 
     subject { translator.translate 'hola', :from => :es, :to => :en }
 
-    it "throws a BingTranslator::AuthenticationException exception" do
-      expect { subject }.to raise_error(BingTranslator::AuthenticationException)
+    it "throws a BingTranslator::Exception exception" do
+      expect { subject }.to raise_error(BingTranslator::Exception)
     end
 
     context "trying to translate something twice" do
-      it "throws the BingTranslator::AuthenticationException exception every time" do
-        2.times { expect { subject }.to raise_error(BingTranslator::AuthenticationException) }
-      end
-    end
-  end
-
-  describe "#balance" do
-    context "when azure account key has been defined" do
-      it "returns the balance" do
-        balance = translator.balance
-
-        balance.should be_a Fixnum
-      end
-    end
-
-    context "when azure account has been defined" do
-      let(:translator) { BingTranslator.new(client_id: "", client_secret: "") }
-
-      it "raises an exception" do
-        expect { translator.balance }.to raise_error
+      it "throws the BingTranslator::Exception exception every time" do
+        2.times { expect { subject }.to raise_error(BingTranslator::Exception) }
       end
     end
   end

--- a/spec/bing_translator_spec.rb
+++ b/spec/bing_translator_spec.rb
@@ -69,6 +69,9 @@ describe BingTranslator do
     result = translator.detect message_en
     result.should == :en
 
+    result = translator.detect ' '
+    result.should == nil
+
     result = translator.detect "Это сообщение должно быть переведено"
     result.should == :ru
 

--- a/spec/bing_translator_spec.rb
+++ b/spec/bing_translator_spec.rb
@@ -27,10 +27,11 @@ describe BingTranslator do
   let(:long_unicode_text) { File.read(File.join(File.dirname(__FILE__), 'long_unicode_text.txt')) }
   let(:long_html_text) { File.read(File.join(File.dirname(__FILE__), 'long_text.html')) }
   let(:translator) {
-    BingTranslator.new(ENV['BING_TRANSLATOR_TEST_CLIENT_ID'],
-      ENV['BING_TRANSLATOR_TEST_CLIENT_SECRET'],
-      false,
-      ENV['AZURE_TEST_ACCOUNT_KEY'])
+    BingTranslator.new(client_id: ENV['BING_TRANSLATOR_TEST_CLIENT_ID'],
+      client_secret: ENV['BING_TRANSLATOR_TEST_CLIENT_SECRET'],
+      skip_ssl_verify: false,
+      account_key: ENV['AZURE_TEST_ACCOUNT_KEY'],
+      subscription_key: ENV['COGNITIVE_SUBSCRIPTION_KEY'])
   }
 
   it "translates text" do
@@ -77,9 +78,9 @@ describe BingTranslator do
 
   it "translates array of texts, with word alignment information" do
     result = translator.translate_array2 [message_en, message_en_other], :from => :en, :to => :de
-    result.should == [["Diese Meldung sollte übersetzt werden", 
-                       "0:3-0:4 5:11-6:12 13:18-14:19 20:21-31:36 23:32-21:29"], 
-                      ["Diese Meldung sollte auch übersetzt werden", 
+    result.should == [["Diese Meldung sollte übersetzt werden",
+                       "0:3-0:4 5:11-6:12 13:18-14:19 20:21-31:36 23:32-21:29"],
+                      ["Diese Meldung sollte auch übersetzt werden",
                        "0:3-0:4 5:11-6:12 13:18-14:19 20:21-36:41 23:25-21:24 27:36-26:34"]]
   end
 
@@ -126,7 +127,7 @@ describe BingTranslator do
   end
 
   context 'when credentials are invalid' do
-    let(:translator) { BingTranslator.new("", "") }
+    let(:translator) { BingTranslator.new(client_id: "", client_secret: "") }
 
     subject { translator.translate 'hola', :from => :es, :to => :en }
 
@@ -151,7 +152,7 @@ describe BingTranslator do
     end
 
     context "when azure account has been defined" do
-      let(:translator) { BingTranslator.new("", "") }
+      let(:translator) { BingTranslator.new(client_id: "", client_secret: "") }
 
       it "raises an exception" do
         expect { translator.balance }.to raise_error

--- a/spec/bing_translator_spec.rb
+++ b/spec/bing_translator_spec.rb
@@ -4,22 +4,6 @@ require 'rspec-html-matchers'
 
 require File.join(File.dirname(__FILE__), '..', 'lib', 'bing_translator')
 
-# Log all the tasks output, keeping RSpec interface clean while running
-RSpec.configure do |config|
-  original_stderr = $stderr
-  original_stdout = $stdout
-  config.before(:all) do
-    # Redirect stderr and stdout
-    $stderr = File.new(File.join(File.dirname(__FILE__), 'stderr.log'), 'w')
-    $stdout = File.new(File.join(File.dirname(__FILE__), 'stdout.log'), 'w')
-  end
-  config.after(:all) do
-    # Return stderr and stdout back in to the place
-    $stderr = original_stderr
-    $stdout = original_stdout
-  end
-end
-
 describe BingTranslator do
   let(:message_en) { "This message should be translated" }
   let(:message_en_other) { "This message should be too translated" }


### PR DESCRIPTION
Microsoft has "moved" the Translator API in the Azure Cognitive Services space. This pull request add supports to the auth it requires.

See https://azure.microsoft.com/en-us/services/cognitive-services/
