### PR TITLE
Feature/http timeouts

### DIFF
--- a/lib/bing_translator.rb
+++ b/lib/bing_translator.rb
@@ -17,9 +17,11 @@ class BingTranslator
     COGNITIVE_ACCESS_TOKEN_URI =
       URI.parse('https://api.cognitive.microsoft.com/sts/v1.0/issueToken').freeze
 
-    def initialize(subscription_key, skip_ssl_verify)
+    def initialize(subscription_key, skip_ssl_verify, read_timeout = 60, open_timeout = 60)
       @subscription_key = subscription_key
       @skip_ssl_verify = skip_ssl_verify
+      @read_timeout = read_timeout
+      @open_timeout = open_timeout
     end
 
     def get(path, params: {}, headers: {}, authorization: false)
@@ -59,6 +61,8 @@ class BingTranslator
       http = Net::HTTP.new(uri.host, 443)
       http.use_ssl = true
       http.verify_mode = OpenSSL::SSL::VERIFY_NONE if @skip_ssl_verify
+      http.read_timeout = @read_timeout
+      http.open_timeout = @open_timeout
       http
     end
 
@@ -97,7 +101,9 @@ class BingTranslator
 
   def initialize(subscription_key, options = {})
     skip_ssl_verify = options.fetch(:skip_ssl_verify, false)
-    @api_client = ApiClient.new(subscription_key, skip_ssl_verify)
+    read_timeout = options.fetch(:read_timeout, 60)
+    open_timeout = options.fetch(:open_timeout, 60)
+    @api_client = ApiClient.new(subscription_key, skip_ssl_verify, read_timeout, open_timeout)
   end
 
   def translate(text, params)

--- a/spec/bing_translator_spec.rb
+++ b/spec/bing_translator_spec.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require_relative 'spec_helper'
 
 describe BingTranslator do
@@ -9,7 +10,7 @@ describe BingTranslator do
 
   let(:api_key) { ENV.fetch('COGNITIVE_SUBSCRIPTION_KEY') }
   let(:message_en) { 'This message should be translated' }
-  let(:message_en_other) { 'This message should be too translated' }
+  let(:message_en_other) { 'This message should be translated too' }
   let(:long_text) { load_file('long_text') }
   let(:long_unicode_text) { load_file('long_unicode_text.txt') }
   let(:long_html_text) { load_file('long_text.html') }
@@ -27,7 +28,7 @@ describe BingTranslator do
       expect(result).to eq 'Ce message doit être traduit'
 
       result = translator.translate message_en, from: :en, to: :de
-      expect(result).to eq 'Diese Botschaft sollte übersetzt werden'
+      expect(result).to eq 'Diese Nachricht sollte übersetzt werden'
     end
 
     it 'translates long texts (up to allowed limit)' do
@@ -67,17 +68,17 @@ describe BingTranslator do
   describe '#translate_array' do
     it 'translates array of texts' do
       result = translator.translate_array [message_en, message_en_other], from: :en, to: :fr
-      expect(result).to eq ['Ce message doit être traduit', 'Ce message devrait être trop traduit']
+      expect(result).to eq ['Ce message doit être traduit', 'Ce message doit être traduit aussi']
     end
   end
 
   describe '#translate_array2' do
     it 'translates array of texts, with word alignment information' do
       result = translator.translate_array2 [message_en, message_en_other], from: :en, to: :de
-      expect(result).to eq [['Diese Botschaft sollte übersetzt werden',
+      expect(result).to eq [['Diese Nachricht sollte übersetzt werden',
                              '0:3-0:4 5:11-6:14 13:18-16:21 20:21-33:38 23:32-23:31'],
-                            ['Diese Botschaft sollte zu übersetzt werden',
-                             '0:3-0:4 5:11-6:14 13:18-16:21 23:25-23:24 27:36-26:34']]
+                            ['Diese Nachricht sollte auch übersetzt werden',
+                             '0:3-0:4 5:11-6:14 13:18-16:21 20:21-38:43 23:32-28:36 34:36-23:26']]
     end
   end
 


### PR DESCRIPTION
Allow customizing HTTP timeout for the API calls. 

The API gets slow sometimes, I don't want to wait 60 seconds for my workers to fail. 