### PR TITLE
Find translation results with case-insensitive comparison

### DIFF
--- a/lib/bing_translator.rb
+++ b/lib/bing_translator.rb
@@ -161,9 +161,10 @@ class BingTranslator
 
     data = texts.map { |text| { 'Text' => text } }.to_json
     response_json = api_client.post('/translate', params: params, data: data)
+    to_lang = params[:to].to_s
     response_json.map do |translation|
       # There should be just one translation, but who knows...
-      translation['translations'].find { |result| result['to'] == params[:to].to_s }
+      translation['translations'].find { |result| result['to'].casecmp(to_lang).zero? }
     end
   end
 end

--- a/spec/bing_translator_spec.rb
+++ b/spec/bing_translator_spec.rb
@@ -31,6 +31,11 @@ describe BingTranslator do
       expect(result).to eq 'Diese Nachricht sollte übersetzt werden'
     end
 
+    it 'translates text to complex language code' do
+      result = translator.translate message_en, from: :en, to: :'fr-ca'
+      expect(result).to eq 'Ce message doit être traduit'
+    end
+
     it 'translates long texts (up to allowed limit)' do
       result = translator.translate long_text, from: :en, to: :ru
       expect(result.size).to be > 1000


### PR DESCRIPTION
Microsoft claims e.g. at https://api.cognitive.microsofttranslator.com/languages?api-version=3.0 to support two language codes with regions: `fr-ca` and `pt-pt`

However in the actual response these are normalized to `fr-CA` and `pt-PT` (which is correct per [BCP 47 recommendations](https://tools.ietf.org/html/bcp47#section-2.1.1)).

With the way this gem currently extracts the translated payload, translations to `fr-ca` and `pt-pt` always result in `nil`. This PR fixes this by performing a case-insensitive comparison.

Note that I have used `casecmp.zero?` instead of `casecmp?` because the latter is apparently slower (see https://github.com/rubocop-hq/rubocop-performance/issues/100).