### PR TITLE
Improve HTTP error report when fetching credential

### DIFF
--- a/lib/bing_translator.rb
+++ b/lib/bing_translator.rb
@@ -89,7 +89,7 @@ class BingTranslator
 
       response = http.post(COGNITIVE_ACCESS_TOKEN_URI.path, '', headers)
       if response.code != '200'
-        raise Exception.new('Invalid credentials')
+        raise Exception.new("Unsuccessful Access Token call: Code: #{response.code} (Invalid credentials?)")
       else
         @access_token_expiration_time = Time.now + 480
         response.body


### PR DESCRIPTION
Any sort of HTTP error can be returned here, so without the status code it's ambiguous what the actual error was.

This still doesn't include the error message from the server, however it is a first step towards less ambiguity in the error.

I based the method off the other HTTP status code error in this file.