### PR TITLE
Distinguish errors by Exception class

### DIFF
--- a/bing_translator.gemspec
+++ b/bing_translator.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'bing_translator'
-  s.version     = '6.1.0'
+  s.version     = '6.2.0'
   s.date        = '2019-03-25'
   s.homepage    = 'https://www.github.com/relrod/bing_translator-gem'
   s.summary     = 'Translate using the Bing HTTP API'

--- a/bing_translator.gemspec
+++ b/bing_translator.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'bing_translator'
-  s.version     = '6.2.0'
+  s.version     = '6.1.0'
   s.date        = '2019-03-25'
   s.homepage    = 'https://www.github.com/relrod/bing_translator-gem'
   s.summary     = 'Translate using the Bing HTTP API'

--- a/lib/bing_translator.rb
+++ b/lib/bing_translator.rb
@@ -99,7 +99,7 @@ class BingTranslator
       when Net::HTTPServerError
         raise UnavailableException.new("#{response.code}: Credentials server unavailable")
       else
-        raise Exception.new("Unsuccessful Access Token call: Code: #{response.code} (Invalid credentials?)")
+        raise AuthenticationException.new("Unsuccessful Access Token call: Code: #{response.code} (Invalid credentials?)")
       end
     end
   end

--- a/lib/bing_translator.rb
+++ b/lib/bing_translator.rb
@@ -92,13 +92,14 @@ class BingTranslator
       http.verify_mode = OpenSSL::SSL::VERIFY_NONE if @skip_ssl_verify
 
       response = http.post(COGNITIVE_ACCESS_TOKEN_URI.path, '', headers)
-      if response.code == '503'
-        raise UnavailableException.new('503: Credentials server unavailable')
-      elsif response.code != '200'
-        raise AuthenticationException.new('Invalid credentials')
-      else
+      case response
+      when Net::HTTPSuccess
         @access_token_expiration_time = Time.now + 480
         response.body
+      when Net::HTTPServerError
+        raise UnavailableException.new("#{response.code}: Credentials server unavailable")
+      else
+        raise AuthenticationException.new('Invalid credentials')
       end
     end
   end

--- a/spec/bing_translator_spec.rb
+++ b/spec/bing_translator_spec.rb
@@ -61,7 +61,27 @@ describe BingTranslator do
       it 'throws a reasonable error' do
         expect { translator.translate 'hola', from: :invlaid, to: :en }
           .to raise_error(BingTranslator::Exception)
+        expect { translator.translate 'hola', from: :invlaid, to: :en }
+          .to raise_error(BingTranslator::ApiException)
       end
+    end
+
+    context 'when no target language is specified' do
+      it 'throws a reasonable error' do
+        expect { translator.translate 'hola', from: :es }
+          .to raise_error(BingTranslator::Exception)
+        expect { translator.translate 'hola', from: :es }
+          .to raise_error(BingTranslator::UsageException)
+      end
+    end
+  end
+
+  describe '#speak' do
+    it 'will always throw an exception' do
+      expect { translator.speak 'hola', from: :es, to: :en }
+        .to raise_error(BingTranslator::Exception)
+      expect { translator.speak 'hola', from: :es, to: :en }
+        .to raise_error(BingTranslator::UsageException)
     end
   end
 
@@ -124,13 +144,15 @@ describe BingTranslator do
 
     subject { translator.translate 'hola', from: :es, to: :en }
 
-    it 'throws a BingTranslator::Exception exception' do
+    it 'throws a BingTranslator::AuthenticationException exception' do
       expect { subject }.to raise_error(BingTranslator::Exception)
+      expect { subject }.to raise_error(BingTranslator::AuthenticationException)
     end
 
     context 'trying to translate something twice' do
-      it 'throws the BingTranslator::Exception exception every time' do
+      it 'throws the BingTranslator::AuthenticationException exception every time' do
         2.times { expect { subject }.to raise_error(BingTranslator::Exception) }
+        2.times { expect { subject }.to raise_error(BingTranslator::AuthenticationException) }
       end
     end
   end
@@ -178,6 +200,7 @@ describe BingTranslator do
 
         it 'throws an error' do
           expect { subject }.to raise_error(BingTranslator::Exception)
+          expect { subject }.to raise_error(BingTranslator::ApiException)
         end
       end
 

--- a/spec/bing_translator_spec.rb
+++ b/spec/bing_translator_spec.rb
@@ -103,7 +103,7 @@ describe BingTranslator do
         expect { authenticating_translator.translate 'hola', from: :es, to: :en }
           .to raise_error(BingTranslator::Exception)
         expect { authenticating_translator.translate 'hola', from: :es, to: :en }
-          .to raise_error(BingTranslator::AuthenticationException, "Unsuccessful Access Token call: Code: 303 (Invalid credentials?)")
+          .to raise_error(BingTranslator::AuthenticationException, "Unsuccessful Access Token call: Code: 401 (Invalid credentials?)")
       end
 
       it 'throws an AuthenticationException if HTTP response code is not 200 or 5XX' do

--- a/spec/bing_translator_spec.rb
+++ b/spec/bing_translator_spec.rb
@@ -92,6 +92,29 @@ describe BingTranslator do
       end
     end
 
+    context 'when the authentication server is online' do
+      it 'throws an AuthenticationException if the authentication key is invalid' do
+        fake_api_key = '32'
+        authenticating_translator = BingTranslator.new(fake_api_key, skip_ssl_verify: false)
+
+        expect { authenticating_translator.translate 'hola', from: :es, to: :en }
+          .to raise_error(BingTranslator::Exception)
+        expect { authenticating_translator.translate 'hola', from: :es, to: :en }
+          .to raise_error(BingTranslator::AuthenticationException)
+      end
+
+      it 'throws an AuthenticationException if HTTP response code is not 200 or 5XX' do
+        authenticating_translator = BingTranslator.new(api_key, skip_ssl_verify: false)
+        stub_request(:any, COGNITIVE_ACCESS_TOKEN_URI).
+          to_return(status: [404, 'Not Found'])
+
+        expect { authenticating_translator.translate 'hola', from: :es, to: :en }
+          .to raise_error(BingTranslator::Exception)
+        expect { authenticating_translator.translate 'hola', from: :es, to: :en }
+          .to raise_error(BingTranslator::AuthenticationException)
+      end
+    end
+
     context 'when invalid language is specified' do
       it 'throws a reasonable error' do
         expect { translator.translate 'hola', from: :invlaid, to: :en }

--- a/spec/bing_translator_spec.rb
+++ b/spec/bing_translator_spec.rb
@@ -81,7 +81,7 @@ describe BingTranslator do
         expect { authenticating_translator.translate 'hola', from: :es, to: :en }
           .to raise_error(BingTranslator::Exception)
         expect { authenticating_translator.translate 'hola', from: :es, to: :en }
-          .to raise_error(BingTranslator::UnavailableException)
+          .to raise_error(BingTranslator::UnavailableException, '500: Credentials server unavailable')
       end
 
       it 'throws a reasonable error with a different 5XX error' do
@@ -91,7 +91,7 @@ describe BingTranslator do
         expect { authenticating_translator.translate 'hola', from: :es, to: :en }
           .to raise_error(BingTranslator::Exception)
         expect { authenticating_translator.translate 'hola', from: :es, to: :en }
-          .to raise_error(BingTranslator::UnavailableException)
+          .to raise_error(BingTranslator::UnavailableException, '503: Credentials server unavailable')
       end
     end
 
@@ -103,7 +103,7 @@ describe BingTranslator do
         expect { authenticating_translator.translate 'hola', from: :es, to: :en }
           .to raise_error(BingTranslator::Exception)
         expect { authenticating_translator.translate 'hola', from: :es, to: :en }
-          .to raise_error(BingTranslator::AuthenticationException)
+          .to raise_error(BingTranslator::AuthenticationException, "Unsuccessful Access Token call: Code: 303 (Invalid credentials?)")
       end
 
       it 'throws an AuthenticationException if HTTP response code is not 200 or 5XX' do
@@ -114,7 +114,7 @@ describe BingTranslator do
         expect { authenticating_translator.translate 'hola', from: :es, to: :en }
           .to raise_error(BingTranslator::Exception)
         expect { authenticating_translator.translate 'hola', from: :es, to: :en }
-          .to raise_error(BingTranslator::AuthenticationException)
+          .to raise_error(BingTranslator::AuthenticationException, "Unsuccessful Access Token call: Code: 404 (Invalid credentials?)")
       end
     end
 

--- a/spec/bing_translator_spec.rb
+++ b/spec/bing_translator_spec.rb
@@ -71,23 +71,26 @@ describe BingTranslator do
     end
 
     context 'when the authentication server is offline' do
+      # Use a new, non-cached translator so that we guarantee hitting the authentication server
+      let(:authenticating_translator) { described_class.new(api_key, skip_ssl_verify: false) }
+
       it 'throws a reasonable error when a 500 error is encountered' do
         stub_request(:any, COGNITIVE_ACCESS_TOKEN_URI).
-          to_return(status: [500, "Internal Server Error"])
+          to_return(status: [500, 'Internal Server Error'])
 
-        expect { translator.translate 'hola', from: :es, to: :en }
+        expect { authenticating_translator.translate 'hola', from: :es, to: :en }
           .to raise_error(BingTranslator::Exception)
-        expect { translator.translate 'hola', from: :es, to: :en }
+        expect { authenticating_translator.translate 'hola', from: :es, to: :en }
           .to raise_error(BingTranslator::UnavailableException)
       end
 
       it 'throws a reasonable error with a different 5XX error' do
         stub_request(:any, COGNITIVE_ACCESS_TOKEN_URI).
-          to_return(status: [503, "Service Unavailable"])
+          to_return(status: [503, 'Service Unavailable'])
 
-        expect { translator.translate 'hola', from: :es, to: :en }
+        expect { authenticating_translator.translate 'hola', from: :es, to: :en }
           .to raise_error(BingTranslator::Exception)
-        expect { translator.translate 'hola', from: :es, to: :en }
+        expect { authenticating_translator.translate 'hola', from: :es, to: :en }
           .to raise_error(BingTranslator::UnavailableException)
       end
     end


### PR DESCRIPTION
Recently Microsoft had wide outages across their various products.  The translate API was unable to obtain the right credentials and failed with error `Invalid credentials`.  The real issue was a `503 service unavailable`.

This PR does 2 things:
- distinguishes each unique error type by a new exception class.  Users can rescue on those classes, rather than rescuing all errors and needing to check the contents of the error to determine what to do
- catch and raise on 503 service unavailable

The first point is done in a backwards compatible way.  Existing code that rescues on `BingTranslator::Exception` will still run as before. With the important exception of catching 503 errors, which have a new unique string associated with them.

I think the second point is redundant with https://github.com/relrod/bing_translator-gem/pull/46 and the solution in the other PR is more generally useful.

----

https://status.azure.com/status/history/
`
Between approximately 07:00 UTC and 13:55 UTC on 21 Jul 2021, customers using Cognitive Services may have experienced difficulties connecting to resources. Impacted customers may have experienced timeouts or 401 authorization errors.
`

I personally saw 503 errors for the few cases I debugged but it could be that during the service downtime interval, various error codes were returned.  Maybe catching only 503 is too specific?
